### PR TITLE
Updated worldweatheronline.com's service URL

### DIFF
--- a/PocketForecast/Assembly/Configuration.properties
+++ b/PocketForecast/Assembly/Configuration.properties
@@ -1,6 +1,6 @@
 ## Configuration properties for Pocket Forecast
 
-service.url=http://free.worldweatheronline.com/feed/weather.ashx
+service.url=http://api.worldweatheronline.com/free/v1/weather.ashx
 api.key=$$YOUR_API_KEY_HERE
 days.to.retrieve=5
 


### PR DESCRIPTION
The feed/service URL for worldweatheronline.com has changed from:
- http://free.worldweatheronline.com/feed/weather.ashx

to:
- http://api.worldweatheronline.com/free/v1/weather.ashx

I've tested this out and it works fine.  Thanks!
