### PR TITLE
Fixed typo in test case

### DIFF
--- a/PocketForecastTests/Integration/PFWeatherClientTests.m
+++ b/PocketForecastTests/Integration/PFWeatherClientTests.m
@@ -38,7 +38,7 @@
     TyphoonComponentFactory * factory = [TyphoonBlockComponentFactory factoryWithAssemblies:@[[PFCoreComponents assembly]]];
 
     TyphoonConfigPostProcessor* configurer = [TyphoonConfigPostProcessor configurer];
-    [configurer useResourceWithName:@"Configuration.properties"];
+    [configurer useResourceWithName:@"Configuration.plist"];
     [factory attachPostProcessor:configurer];
 
 


### PR DESCRIPTION
The test case failed since there is no `Configuration.properties` but a `Configuration.plist` in the bundle
